### PR TITLE
typo in pageYOffset causes IE 9-11 to zoom wrong

### DIFF
--- a/js/zoom.js
+++ b/js/zoom.js
@@ -133,7 +133,7 @@ var zoom = (function(){
 	function getScrollOffset() {
 		return {
 			x: window.scrollX !== undefined ? window.scrollX : window.pageXOffset,
-			y: window.scrollY !== undefined ? window.scrollY : window.pageXYffset
+			y: window.scrollY !== undefined ? window.scrollY : window.pageYOffset
 		}
 	}
 


### PR DESCRIPTION
Please merge, will fix IE :-)
