### PR TITLE
Add optional padding

### DIFF
--- a/js/zoom.js
+++ b/js/zoom.js
@@ -208,6 +208,9 @@ var zoom = (function(){
 					options.x *= options.scale;
 					options.y *= options.scale;
 
+					options.x = (options.x < 0) ? 0 : options.x;
+					options.y = (options.y < 0) ? 0 : options.y;
+
 					magnify( options, options.scale );
 
 					if( options.pan !== false ) {


### PR DESCRIPTION
1. Add padding option when zooming into specific element.
2. Set option.x and option.y to '0' when scroll move out of document.
